### PR TITLE
CORE-3090 - feat: allowing voice property in SIntentInput type

### DIFF
--- a/src/models/shared.ts
+++ b/src/models/shared.ts
@@ -43,6 +43,7 @@ export type DiagramID = s.StructType<typeof SDiagramID>;
 export const SIntentInput = s.object({
   text: s.string(),
   slots: s.optional(s.array(s.string())),
+  voice: s.optional(s.string()),
 });
 export type IntentInput = s.StructType<typeof SIntentInput>;
 


### PR DESCRIPTION
## Description
Updating a `superstruct` type so that new data that we need for Slot Prompt / Confirmation SSML doesn't trigger an error in one of the `superstruct` assertions.

## Related PRs
| project              | PR          |
| ------------------- | ----------- |
| `google-service` | [link](https://github.com/voiceflow/google-service/pull/44) |
| `alexa-service`     | [link](https://github.com/voiceflow/alexa-service/pull/91) |
| `creator-app`     | [link](https://github.com/voiceflow/creator-app/pull/2776) |