### PR TITLE
feat: API Key Verification (CORE-5221)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,17 +36,11 @@ export class PublicClient {
 }
 
 export class Client extends PublicClient {
-  public user?: User;
-
-  isAPIKey(authorization: string): boolean {
-    return authorization.startsWith('VF.');
-  }
+  public user: User;
 
   constructor({ clientKey, apiEndpoint, authorization, options }: Omit<ClientOptions, 'authorization'> & { authorization: string }) {
     super({ clientKey, apiEndpoint, authorization, options });
 
-    if (authorization && !this.isAPIKey(authorization)) {
-      this.user = new User(authorization);
-    }
+    this.user = new User(authorization);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,11 +36,17 @@ export class PublicClient {
 }
 
 export class Client extends PublicClient {
-  public user: User;
+  public user?: User;
+
+  isAPIKey(authorization: string): boolean {
+    return authorization.startsWith('VF.');
+  }
 
   constructor({ clientKey, apiEndpoint, authorization, options }: Omit<ClientOptions, 'authorization'> & { authorization: string }) {
     super({ clientKey, apiEndpoint, authorization, options });
 
-    this.user = new User(authorization);
+    if (authorization && !this.isAPIKey(authorization)) {
+      this.user = new User(authorization);
+    }
   }
 }

--- a/src/resources/user.ts
+++ b/src/resources/user.ts
@@ -24,18 +24,24 @@ type UserToken = {
 };
 
 class User {
-  public creatorID: CreatorID;
+  public creatorID: CreatorID = 0;
 
-  public name: string;
+  public name = '';
 
-  public email: string;
+  public email = '';
+
+  isAPIKey(authorization: string): boolean {
+    return authorization.startsWith('VF.');
+  }
 
   constructor(authorization: string) {
-    const { id, name, email } = parseJWT<UserToken>(authorization);
+    if (!this.isAPIKey(authorization)) {
+      const { id, name, email } = parseJWT<UserToken>(authorization);
 
-    this.creatorID = id;
-    this.name = name;
-    this.email = email;
+      this.creatorID = id;
+      this.name = name;
+      this.email = email;
+    }
   }
 }
 

--- a/tests/client.unit.ts
+++ b/tests/client.unit.ts
@@ -7,18 +7,25 @@ import { APIKey, Diagram, Program, Project, PrototypeProgram, User, Version } fr
 
 const CLIENT_RESOURCES = [Fetch, Diagram, Program, Project, Version, User, APIKey];
 
-const createClient = () =>
+const createClient = (authorization?: string) =>
   new Client({
     clientKey: '123qwe123',
     apiEndpoint: 'apiEndpoint',
-    authorization: JWT.sign({}, 'test'),
+    authorization: authorization ?? JWT.sign({}, 'test'),
   });
 
 describe('Client', () => {
   it('.constructor', () => {
     const client = createClient();
-
     expect(Object.values(client).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
+
+    const noAuthClient = createClient('');
+    expect(Object.values(noAuthClient).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
+    expect(noAuthClient.user).to.eql(undefined);
+
+    const apiKeyClient = createClient('VF.ApiKey');
+    expect(Object.values(apiKeyClient).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
+    expect(apiKeyClient.user).to.eql(undefined);
   });
 
   it('.project', () => {

--- a/tests/client.unit.ts
+++ b/tests/client.unit.ts
@@ -18,14 +18,6 @@ describe('Client', () => {
   it('.constructor', () => {
     const client = createClient();
     expect(Object.values(client).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
-
-    const noAuthClient = createClient('');
-    expect(Object.values(noAuthClient).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
-    expect(noAuthClient.user).to.eql(undefined);
-
-    const apiKeyClient = createClient('VF.ApiKey');
-    expect(Object.values(apiKeyClient).every((resource) => CLIENT_RESOURCES.some((Resource) => resource instanceof Resource))).to.eql(true);
-    expect(apiKeyClient.user).to.eql(undefined);
   });
 
   it('.project', () => {

--- a/tests/resources/user.unit.ts
+++ b/tests/resources/user.unit.ts
@@ -37,4 +37,14 @@ describe('UserResource', () => {
     // @ts-expect-error
     global.window = undefined;
   });
+
+  it('.constructor with API key', () => {
+    const DEFAULT_USER = {
+      creatorID: 0,
+      name: '',
+      email: '',
+    };
+
+    expect(new User('VF.APIkey')).to.eql(DEFAULT_USER);
+  });
 });


### PR DESCRIPTION
**Fixes or implements CORE-5221**

### Brief description. What is this change?
Allows for API key support in general-runtime when hitting the interact endpoint.

### Implementation details. How do you make this change?
If a client is created with an API key, a user is not created as the required fields can only be extracted from a vf_auth token.

### Related PRs
| branch              | PR          |
| ------------------- | ----------- |
| general-runtime | [link](https://github.com/voiceflow/general-runtime/pull/65) |

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ✅  ] appropriate tests have been written
- [ ✅  ] all the dependencies are upgraded