### PR TITLE
ci(circleci): removed pr validation on circleci and added to GHA (CORE-5126)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   codecov: codecov/codecov@1.0.2
   vfcommon: voiceflow/common@0.0.67
   sonarcloud: sonarsource/sonarcloud@1.0.2
-  validate-title: qventus/validate-title@0.0.4
 
 jobs:
   build-and-test:
@@ -24,19 +23,6 @@ jobs:
       - sonarcloud/scan
 
 workflows:
-  pr-checker:
-    jobs:
-      - validate-title/validate:
-          context: dev-test
-          regex: >-
-            $PR_REGEX
-          filters:
-            branches:
-              ignore:
-                - /env-.*/
-                - staging
-                - master
-
   test-and-release:
     jobs:
       - build-and-test:

--- a/.github/workflows/pr-checker.yaml
+++ b/.github/workflows/pr-checker.yaml
@@ -1,0 +1,15 @@
+name: PR Title validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-validation:
+    name: Checks if the PR title is valid
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: ${{ secrets.PR_TITLE_REGEX }} # Regex the title should match.
+          github_token: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
**Fixes or implements CORE-5126**

### Brief description. What is this change?

removed PR validation from CircleCI and added as a GHA

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded