### PR TITLE
feat: reinstated prototype share plan checks (VF-678)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/voiceflow/api-sdk/branch/master/graph/badge.svg?token=I7UDBF71DB)](https://codecov.io/gh/voiceflow/api-sdk)
 [![sonar quality gate](https://sonarcloud.io/api/project_badges/measure?project=voiceflow_api-sdk&metric=alert_status)](https://sonarcloud.io/dashboard?id=voiceflow_api-sdk)
 
-SDK for Voiceflow API, with typings for general voiceflow data structures
+SDK for Voiceflow API, with typings for general voiceflow data structures.
 
 ## Getting Started
 

--- a/src/models/version.ts
+++ b/src/models/version.ts
@@ -9,7 +9,7 @@ export const SVersionPlatformDataSettings = s.object();
 
 export const SVersionPlatformDataPublishing = s.object();
 
-// TODO: do not forget to add new field to the StrictVersionPlatformData union
+// TODO: do not forget to add new field to the StrictVersionPlatformData union.
 export const SVersionPlatformData = dynamicObject({
   slots: s.array(SSlot),
   intents: s.array(SIntent),

--- a/src/resources/version.ts
+++ b/src/resources/version.ts
@@ -162,6 +162,14 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
 
     return data;
   }
+
+  public async getPrototypePlan(id: VersionID) {
+    this._assertModelID(id);
+
+    const { data } = await this.fetch.get<{ plan: string }>(`${this._getCRUDEndpoint(id)}/prototype/plan`);
+
+    return data;
+  }
 }
 
 export default VersionResource;

--- a/tests/resources/version.unit.ts
+++ b/tests/resources/version.unit.ts
@@ -392,4 +392,22 @@ describe('VersionResource', () => {
     expect(assert.callCount).to.eql(1);
     expect(assert.args[0]).to.eql(['1', resource['struct'].schema._id]);
   });
+
+  it('getPrototypePlan', async () => {
+    const { fetch, assert, resource } = createClient();
+
+    const response = { data: 'dummy' };
+
+    fetch.get.resolves(response);
+
+    const versionID = '1';
+
+    const data = await resource.getPrototypePlan(versionID);
+
+    expect(assert.callCount).to.eql(1);
+    expect(assert.args[0]).to.eql(['1', resource['struct'].schema._id]);
+    expect(fetch.get.callCount).to.eql(1);
+    expect(fetch.get.args[0]).to.eql([`versions/${versionID}/prototype/plan`]);
+    expect(data).to.eql(response.data);
+  });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-678**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

This is the "proper" solution for the "cannot fetch workspaces bug" (linked in the ticket VF-678). The issue was that the `fetchWorkspaces` side-effect used to determine the workspace plan of the prototype, required the user to be logged in, which is not true if the app hasn't cached/persisted any login information. This and related PRs implement logic to fetch the workspace plan based on the prototype version ID and not the authentication info. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

This is the `api-sdk` around the endpoint introduced by the related `creator-api` changes. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

None

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

None

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| `creator-app` | [link](https://github.com/voiceflow/creator-app/pull/3232) |
| `creator-api` | [link](https://github.com/voiceflow/creator-api/pull/658) |
|  `api-sdk`  | [link](https://github.com/voiceflow/api-sdk/pull/57) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- ~~[ ] all the dependencies are upgraded~~